### PR TITLE
fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 dl_api = "0.4"
 human = "0.1"
-pasts = "0.6"
+pasts = "0.5"
 
 [features]
 default = []


### PR DESCRIPTION
Looks like https://github.com/libcala/window/pull/6 broke the build:
```
warning: unused import: `pasts::prelude::*`
 --> src/input.rs:6:5
  |
6 | use pasts::prelude::*;
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `pasts::prelude::*`
 --> src/input.rs:6:5
  |
6 | use pasts::prelude::*;
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0599]: no method named `fut` found for opaque type `impl Future` in the current scope
  --> src/input.rs:10:21
   |
10 |     [human::input().fut(), crate::ffi::input().fut()]
   |                     ^^^ method not found in `impl Future`
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
           `use pasts::dyn_future::DynFut;`

error[E0599]: no method named `fut` found for opaque type `impl Future` in the current scope
  --> src/input.rs:10:48
   |
10 |     [human::input().fut(), crate::ffi::input().fut()]
   |                                                ^^^ method not found in `impl Future`
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
           `use pasts::dyn_future::DynFut;`

error[E0599]: no method named `fut` found for opaque type `impl Future` in the current scope
  --> src/input.rs:10:21
   |
10 |     [human::input().fut(), crate::ffi::input().fut()]
   |                     ^^^ method not found in `impl Future`
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
           `use pasts::dyn_future::DynFut;`

error[E0599]: no method named `fut` found for opaque type `impl Future` in the current scope
  --> src/input.rs:10:48
   |
10 |     [human::input().fut(), crate::ffi::input().fut()]
   |                                                ^^^ method not found in `impl Future`
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
           `use pasts::dyn_future::DynFut;`

error: aborting due to 2 previous errors; 1 warning emitted

For more information about this error, try `rustc --explain E0599`.
error: aborting due to 2 previous errors; 1 warning emitted

For more information about this error, try `rustc --explain E0599`.
error: could not compile `window`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```